### PR TITLE
Use relative paths in header

### DIFF
--- a/themes/lisa-theme/layouts/partials/header.html
+++ b/themes/lisa-theme/layouts/partials/header.html
@@ -9,7 +9,7 @@
   <div class="info overflow-auto mb3">
     <ul class="list-reset block">
       {{- range .Site.Pages.ByWeight }}
-        <li class="left mr2"><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+        <li class="left mr2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
       {{- end }}
     </ul>
   </div>


### PR DESCRIPTION
I'd rather do something that was absolute from the site root i.e.
"/about/" instead of absolute with site URL or truly relative i.e.
"../about/", but this seems like a reasonable solution.