### PR TITLE
Make all home content left align on mobile

### DIFF
--- a/themes/lisa-theme/static/css/_components.styl
+++ b/themes/lisa-theme/static/css/_components.styl
@@ -117,3 +117,7 @@
 .col-6-override
   width: 50%
   float: left
+
+.sm-col-12
+  +below($desktop)
+    padding-left: 0

--- a/themes/lisa-theme/static/css/main.css
+++ b/themes/lisa-theme/static/css/main.css
@@ -203,6 +203,11 @@ a:hover img {
   width: 50%;
   float: left;
 }
+@media screen and (max-width: 1000px) {
+  .sm-col-12 {
+    padding-left: 0;
+  }
+}
 @-moz-keyframes text-fade {
   0% {
     opacity: 0;


### PR DESCRIPTION
Since the content is two columns with padding in the middle on desktop,
we need some extra styling to remove that padding on mobile to make sure
that all of the content lines up.